### PR TITLE
Add manual update check feature to settings modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lexware-obx-importer",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/stamp-release-version.ts
+++ b/scripts/stamp-release-version.ts
@@ -7,7 +7,8 @@ interface TauriConfig {
 }
 
 export function createStampedReleaseVersion(baseVersion: string): string {
-  return `${baseVersion}-main.${String(Date.now())}`;
+  const [major, minor, patch] = baseVersion.split(".").map(Number);
+  return `${major}.${minor}.${patch + 1}-main.${String(Date.now())}`;
 }
 
 function stampTauriConfigContent(

--- a/scripts/stamp-release-version.ts
+++ b/scripts/stamp-release-version.ts
@@ -7,8 +7,7 @@ interface TauriConfig {
 }
 
 export function createStampedReleaseVersion(baseVersion: string): string {
-  const [major, minor, patch] = baseVersion.split(".").map(Number);
-  return `${major}.${minor}.${patch + 1}-main.${String(Date.now())}`;
+  return `${baseVersion}-main.${String(Date.now())}`;
 }
 
 function stampTauriConfigContent(

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lexware-obx-importer"
-version = "0.2.1"
+version = "0.2.2"
 description = "Import all products from an OBX as an offer to lexware"
 authors = ["Florian Richter"]
 edition = "2021"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,15 +14,20 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_opener::init())
+        .invoke_handler(tauri::generate_handler![trigger_update])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }
 
-async fn update(app: tauri::AppHandle) -> tauri_plugin_updater::Result<()> {
+#[tauri::command]
+async fn trigger_update(app: tauri::AppHandle) -> Result<bool, String> {
+    update(app).await.map_err(|e| e.to_string())
+}
+
+async fn update(app: tauri::AppHandle) -> tauri_plugin_updater::Result<bool> {
     if let Some(update) = app.updater()?.check().await? {
         let mut downloaded = 0;
 
-        // alternatively we could also call update.download() and update.install() separately
         update
             .download_and_install(
                 |chunk_length, content_length| {
@@ -37,7 +42,8 @@ async fn update(app: tauri::AppHandle) -> tauri_plugin_updater::Result<()> {
 
         println!("update installed");
         app.restart();
+        Ok(true)
+    } else {
+        Ok(false)
     }
-
-    Ok(())
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "lexware-obx-importer",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "de.richter-labor.obx",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -220,9 +220,7 @@ export function SettingsModal({
                 {updateStatus === "checking" ? "Suche…" : "Nach Updates suchen"}
               </button>
               {updateStatus === "up-to-date" && (
-                <span className="text-gray-600 text-sm">
-                  Bereits aktuell
-                </span>
+                <span className="text-gray-600 text-sm">Bereits aktuell</span>
               )}
               {updateStatus === "updated" && (
                 <span className="text-green-600 text-sm">

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -4,6 +4,7 @@ import {
   DialogPanel,
   DialogTitle,
 } from "@headlessui/react";
+import { invoke } from "@tauri-apps/api/core";
 import { useState } from "react";
 import * as XLSX from "xlsx";
 import { kmLogin } from "../api.ts";
@@ -31,6 +32,21 @@ export function SettingsModal({
   const [testStatus, setTestStatus] = useState<
     "testing" | "success" | `error: ${string}` | null
   >(null);
+  const [updateStatus, setUpdateStatus] = useState<
+    "checking" | "up-to-date" | "updated" | `error: ${string}` | null
+  >(null);
+
+  const handleUpdate = async () => {
+    setUpdateStatus("checking");
+    try {
+      const found = await invoke<boolean>("trigger_update");
+      setUpdateStatus(found ? "updated" : "up-to-date");
+    } catch (err) {
+      setUpdateStatus(
+        `error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  };
 
   const handleTestCredentials = async () => {
     setTestStatus("testing");
@@ -193,7 +209,32 @@ export function SettingsModal({
             </div>
           </div>
 
-          <div className="flex justify-end">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                disabled={updateStatus === "checking"}
+                onClick={handleUpdate}
+                className="rounded-md bg-gray-100 px-3 py-1.5 font-medium text-gray-700 text-sm hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {updateStatus === "checking" ? "Suche…" : "Nach Updates suchen"}
+              </button>
+              {updateStatus === "up-to-date" && (
+                <span className="text-gray-600 text-sm">
+                  Bereits aktuell
+                </span>
+              )}
+              {updateStatus === "updated" && (
+                <span className="text-green-600 text-sm">
+                  Update wird installiert…
+                </span>
+              )}
+              {updateStatus?.startsWith("error") && (
+                <span className="text-red-600 text-sm">
+                  {updateStatus.replace("error: ", "")}
+                </span>
+              )}
+            </div>
             <button
               type="button"
               onClick={onClose}


### PR DESCRIPTION
## Summary
This PR adds a manual update check feature to the application settings modal, allowing users to explicitly check for and install updates without waiting for automatic checks.

## Key Changes
- **Frontend (SettingsModal.tsx)**:
  - Added `updateStatus` state to track update checking progress and results
  - Implemented `handleUpdate()` function that invokes the Tauri `trigger_update` command
  - Added update check button with status feedback in the settings modal
  - Displays contextual messages: "Suche…" while checking, "Bereits aktuell" if up-to-date, "Update wird installiert…" if updating, or error messages if something fails

- **Backend (src-tauri/lib.rs)**:
  - Created new `trigger_update` Tauri command that exposes the update functionality to the frontend
  - Refactored existing `update()` function to return `bool` indicating whether an update was found and installed
  - Registered the command in the invoke handler
  - Improved error handling by converting `tauri_plugin_updater::Result` to `Result<bool, String>` for frontend compatibility

- **Version Bumps**:
  - Updated version from 0.2.1 to 0.2.2 in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`

## Implementation Details
- The update check is non-blocking and provides real-time status feedback to the user
- The button is disabled during the checking process to prevent multiple concurrent requests
- Error messages are extracted and displayed to the user for debugging purposes
- The backend properly distinguishes between "update found and installed" vs "already up-to-date" scenarios

https://claude.ai/code/session_01DT52P6EvZed5GkJrKyYX6N