### PR TITLE
Improve security and fix shell injection vulnerability

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   biome:
     name: Lint & Format Check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     name: TypeScript & Build

--- a/scripts/create_release.ts
+++ b/scripts/create_release.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { exec } from "node:child_process";
+import { exec, execFile } from "node:child_process";
 import { readFile, writeFile } from "node:fs/promises";
 import { basename } from "node:path";
 import { promisify } from "node:util";
@@ -113,7 +113,7 @@ async function main() {
     await uploadAsset(releaseId, LATEST_JSON_PATH);
 
     console.log("🌐 Opening draft release in browser...");
-    await execAsync(`open ${releaseUrl}`);
+    await promisify(execFile)("open", [releaseUrl]);
 
     console.log("✨ Release process completed successfully!");
   } catch (error) {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2062,7 +2062,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lexware-obx-importer"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,7 +42,6 @@ async fn update(app: tauri::AppHandle) -> tauri_plugin_updater::Result<bool> {
 
         println!("update installed");
         app.restart();
-        Ok(true)
     } else {
         Ok(false)
     }


### PR DESCRIPTION
## Summary
This PR addresses a security vulnerability in the release script and improves GitHub Actions workflow security by following the principle of least privilege.

## Key Changes
- **Security Fix**: Replace `exec()` with `execFile()` in `create_release.ts` to prevent shell injection vulnerabilities when opening the release URL in the browser
- **Workflow Security**: Add explicit `permissions: contents: read` to all GitHub Actions workflows (biome.yml, test.yml, typecheck.yml) to follow least privilege access principles

## Implementation Details
- Updated the import statement to include `execFile` from `node:child_process`
- Changed the browser opening command from using shell string interpolation (`exec(\`open ${releaseUrl}\``) to using `execFile()` with arguments array, which avoids shell interpretation and is safer when handling dynamic values
- Added minimal read-only permissions declaration to workflows, ensuring they only have access to repository contents when needed and cannot modify other resources

https://claude.ai/code/session_01YAaY2sPxc43wfehTnihgiq